### PR TITLE
Update location of Perl module

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
 					<h3>Developer Tools</h3>
 					<h4><a href="https://github.com/samwho/todo-txt-gem">Todo.txt Gem</a></h4>
 					<p>A RubyGem for parsing todo.txt files, by <a href="https://github.com/samwho">Sam Rose</a>.</p>
-					<h4><a href="http://search.cpan.org/~andrew/Text-Todo-v0.2.0/lib/Text/Todo.pm">Text::Todo</a></h4>
+					<h4><a href="https://metacpan.org/pod/Text::Todo">Text::Todo</a></h4>
 					<p>Perl interface to todotxt files by Andrew Fresh.</p>
 				</div>
 			</div>


### PR DESCRIPTION
This page is linking to an old version of the Perl module Text::Todo.  Here's an updated link that will always reference the latest version.

Also, [search.cpan.org is shutting down next month][1], so I've used its replacement instead.

[1]: https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html